### PR TITLE
Support uppercase file extensions

### DIFF
--- a/Mime.php
+++ b/Mime.php
@@ -327,6 +327,8 @@ class Mime implements Core\Parameter\Parameterizable
      */
     public static function getMimeFromExtension($extension)
     {
+        $extension = strtolower($extension);
+        
         if (false === static::extensionExists($extension)) {
             return null;
         }


### PR DESCRIPTION
Sometimes files have uppercase file extensions like `image.JPG`, which would cause a `MimeIsNotFound` exception to be thrown upon instantiation of `Mime`. This proposed fix simply converts the extension to lowercase in `Mime::getMimeFromExtension()`.